### PR TITLE
WIP - Reference number is becoming a compliance number

### DIFF
--- a/djangocms_moderation/backends.py
+++ b/djangocms_moderation/backends.py
@@ -3,3 +3,12 @@ import uuid
 
 def uuid4_backend(**kwargs):
     return uuid.uuid4().hex
+
+
+def sequential_number_backend(**kwargs):
+    """
+    This backed uses moderation request's primary key to produce readable
+    semi-sequential numbers.
+    """
+    moderation_request = kwargs['moderation_request']
+    return str(moderation_request.pk)

--- a/djangocms_moderation/conf.py
+++ b/djangocms_moderation/conf.py
@@ -2,11 +2,15 @@ from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 
 
-DEFAULT_REFERENCE_NUMBER_BACKEND = getattr(settings, 'CMS_MODERATION_DEFAULT_REFERENCE_NUMBER_BACKEND', 'djangocms_moderation.backends.uuid4_backend')
+UUID_BACKEND = 'djangocms_moderation.backends.uuid4_backend'
+SEQUENTIAL_NUMBER_BACKEND = 'djangocms_moderation.backends.sequential_number_backend'
 
 CORE_REFERENCE_NUMBER_BACKENDS = (
-    (DEFAULT_REFERENCE_NUMBER_BACKEND, _('Default')),
+    (UUID_BACKEND, _('Unique alpha-numeric string')),
+    (SEQUENTIAL_NUMBER_BACKEND, _('Sequential number'))
 )
+
+DEFAULT_REFERENCE_NUMBER_BACKEND = getattr(settings, 'CMS_MODERATION_DEFAULT_REFERENCE_NUMBER_BACKEND', UUID_BACKEND)
 
 REFERENCE_NUMBER_BACKENDS = getattr(settings, 'CMS_MODERATION_REFERENCE_NUMBER_BACKENDS', CORE_REFERENCE_NUMBER_BACKENDS)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -353,6 +353,21 @@ class PageModerationRequestTest(BaseTestCase):
         mock_uuid.assert_called_once()
         self.assertEqual(request.reference_number, 'abc123')
 
+    def test_reference_number_sequential_number_backend(self):
+        self.wf2.reference_number_backend = 'djangocms_moderation.backends.sequential_number_backend'
+        request = PageModerationRequest.objects.create(
+            page=self.pg1,
+            language='en',
+            workflow=self.wf2,
+        )
+        request.refresh_from_db()
+        self.assertIsNone(request.reference_number)
+
+        expected = str(request.pk)
+        request.set_reference_number()
+        request.refresh_from_db()
+        self.assertEqual(request.reference_number, expected)
+
 
 class PageModerationRequestActionTest(BaseTestCase):
 


### PR DESCRIPTION
See FIL-263 for more details.
Please note that job number is now called job id and it is now a primary key of the request (#14)