### PR TITLE
FIL-397 - Add preview link to moderationrequest changelist

### DIFF
--- a/djangocms_moderation/admin.py
+++ b/djangocms_moderation/admin.py
@@ -125,9 +125,8 @@ class ModerationRequestAdmin(admin.ModelAdmin):
 
     def get_preview_link(self, obj):
         return format_html(
-            '<a href="{}">{}</a>',
+            '<a href="{}"><span class="cms-icon cms-icon-eye"></span></a>',
             get_object_preview_url(obj.version.content),
-            _('View')
         )
     get_preview_link.short_description = _('Preview')
 

--- a/djangocms_moderation/templates/djangocms_moderation/moderation_request_change_list.html
+++ b/djangocms_moderation/templates/djangocms_moderation/moderation_request_change_list.html
@@ -1,5 +1,15 @@
 {% extends "admin/change_list.html" %}
-{% load i18n %}
+{% load i18n cms_static %}
+
+{% block extrahead %}
+    {{ block.super }}
+    {#
+        INFO: we need to add styles here instead of "extrastyle" to avoid
+        conflicts with adminstyle. We are adding cms.base.css to gain the
+        icon support, e.g. `<span class="cms-icon cms-icon-eye"></span>`
+    #}
+    <link rel="stylesheet" href="{% static_with_version 'cms/css/cms.base.css' %}">
+{% endblock extrahead %}
 
 {% block content_title %}
     {% if collection %}


### PR DESCRIPTION
And display content type

Please note that by clicking the preview link, you might enter the neverending redirect loop. This is a known bug in versioning, and will be fixed in newer versions